### PR TITLE
feat: use observables for data repositories

### DIFF
--- a/packages/desktop-shell/package-lock.json
+++ b/packages/desktop-shell/package-lock.json
@@ -78,6 +78,20 @@
         }
       }
     },
+    "@ckapp/math": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@ckapp/math/-/math-0.0.3.tgz",
+      "integrity": "sha512-0POl+tjn/8LqwwxjNxeZHwMUrHzc4wNugBeruRuY/x+iXTjpvmaVR367cwitC3ZNJlGFrmYpK3eL1JOKZncuqg=="
+    },
+    "@ckapp/rxjs": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@ckapp/rxjs/-/rxjs-0.0.9.tgz",
+      "integrity": "sha512-3jP6DmrogWllh9cngx1XmUVws9BqmwCBRtVK5YWh/Avw7v3BfN+Uz/Z6Flla9RFJhAv79HmrcL/2b2CoA2AsSA==",
+      "requires": {
+        "@ckapp/math": "^0.0.3",
+        "rxjs": "^6.4.0"
+      }
+    },
     "@electron-forge/async-ora": {
       "version": "6.0.0-beta.54",
       "resolved": "https://registry.npmjs.org/@electron-forge/async-ora/-/async-ora-6.0.0-beta.54.tgz",

--- a/packages/desktop-shell/package.json
+++ b/packages/desktop-shell/package.json
@@ -9,7 +9,7 @@
     "cmd:build": "tsc",
     "cmd:start": "electron-forge start",
     "build:desktop": "npm run cmd:build",
-    "build:watch": "npm run build -- --watch",
+    "build:watch": "tsc --watch",
     "build": "npm run build:desktop",
     "start:desktop": "npm run build:watch",
     "start": "npm run cmd:start",
@@ -68,6 +68,7 @@
     "typescript": "~4.0.2"
   },
   "dependencies": {
+    "@ckapp/rxjs": "^0.0.9",
     "@marblejs/core": "^3.4.3",
     "@marblejs/messaging": "^3.4.3",
     "@marblejs/middleware-body": "^3.4.3",

--- a/packages/desktop-shell/src/repositories/recipe-collection.repository.ts
+++ b/packages/desktop-shell/src/repositories/recipe-collection.repository.ts
@@ -1,6 +1,8 @@
 import * as path from 'path';
 import { Context, createReader, useContext } from '@marblejs/core';
 import { Reader } from 'fp-ts/lib/Reader';
+import { BehaviorSubject, of } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
 
 import { RecipeCollection } from '@overckd/domain';
 import { RecipeCollectionRepository } from '@overckd/domain/dist/repositories/recipe-collection.repository';
@@ -8,32 +10,46 @@ import { fromRecipeCollection } from '@overckd/yaml-parser';
 
 import { AppConfigToken } from '../config/config.token';
 
-let filename: string;
-
-class FileRepo implements RecipeCollectionRepository {
-  getAll(): Promise<RecipeCollection[]> {
-    return fromRecipeCollection(filename).toPromise();
-  }
-  add(collection: RecipeCollection): Promise<RecipeCollection> {
-    throw new Error('Method not implemented.');
-  }
-  removeById(id: string): Promise<boolean> {
-    throw new Error('Method not implemented.');
-  }
-  getById(id: string): Promise<RecipeCollection> {
-    throw new Error('Method not implemented.');
-  }
-  update(collection: RecipeCollection, id: string): Promise<RecipeCollection> {
-    throw new Error('Method not implemented.');
-  }
-}
-
 export const RecipeCollectionFileRespository: Reader<
   Context,
   RecipeCollectionRepository
 > = createReader<RecipeCollectionRepository>(ask => {
   const { paths } = useContext(AppConfigToken)(ask);
 
-  filename = path.join(paths.app, 'overckd.collections.yaml');
-  return new FileRepo();
+  const filename = path.join(paths.app, 'overckd.collections.yaml');
+  const allCollections = new BehaviorSubject<RecipeCollection[]>([]);
+
+  const getById: RecipeCollectionRepository['getById'] = id =>
+    allCollections.pipe(map(f => f.find(c => c.id === id)));
+
+  return {
+    // Queries
+    getAll: () =>
+      fromRecipeCollection(filename).pipe(
+        tap(items => allCollections.next(items)),
+      ),
+    getById,
+    // Commands
+    add: collection =>
+      of(collection).pipe(
+        tap(c => allCollections.next([...allCollections.value, c])),
+      ),
+    removeById: id =>
+      getById(id).pipe(
+        map(x => {
+          if (x === undefined) {
+            return false;
+          }
+
+          const indexOfItem = allCollections.value.indexOf(x);
+          allCollections.next(
+            allCollections.value.filter((_, i) => i !== indexOfItem),
+          );
+          return true;
+        }),
+      ),
+    update: (c, id) => {
+      throw new Error('Method not implemented.');
+    },
+  };
 });

--- a/packages/desktop-shell/src/repositories/recipe.repository.ts
+++ b/packages/desktop-shell/src/repositories/recipe.repository.ts
@@ -1,36 +1,28 @@
 import * as path from 'path';
 import { Context, createReader, useContext } from '@marblejs/core';
 import { Reader } from 'fp-ts/lib/Reader';
+import { BehaviorSubject, from, of } from 'rxjs';
+import { map, mapTo, mergeMap, tap, toArray } from 'rxjs/operators';
+
+import { filterEndsWith } from '@ckapp/rxjs/lib/cjs/string/operators';
 
 import { Recipe } from '@overckd/domain';
 import { RecipeRepository } from '@overckd/domain/dist/repositories';
 import {
-  parseYamlSafe,
   YamlRecipeFile,
   parseRecipeFile,
   toYamlFile,
   dumpYamlSafe,
 } from '@overckd/yaml-parser';
-import { readFile, readDir, writeFile } from '@overckd/yaml-parser/dist/fs';
+import { writeFile } from '@overckd/yaml-parser/dist/fs';
+import { fromDirectory } from '@overckd/yaml-parser/dist/rxjs';
+import {
+  parseYamlSafe,
+  readFile,
+} from '@overckd/yaml-parser/dist/rxjs/operators';
 
 import { AppConfigToken } from '../config/config.token';
 import { getPath, PathId } from '../paths';
-
-let recipesFolder: string;
-
-async function getAllRecipeFilesInFolder(dir: string) {
-  const files = await readDir(dir);
-  const recipeFiles = files
-    .filter(f => f.endsWith('.recipe.yaml'))
-    .map(f => path.resolve(dir, f));
-  return recipeFiles;
-}
-
-async function readRecipeFile(filepath: string) {
-  const fileContent = await readFile(filepath, { encoding: 'utf-8' });
-  const doc = parseYamlSafe<YamlRecipeFile>(fileContent);
-  return parseRecipeFile(doc);
-}
 
 async function saveRecipe(dir: string, id: string, recipe: Recipe) {
   const filename = path.resolve(dir, `${id}.recipe.yaml`);
@@ -43,42 +35,15 @@ async function saveRecipe(dir: string, id: string, recipe: Recipe) {
   return writeFile(filename, fileContent, { encoding: 'utf-8' });
 }
 
-async function readAllRecipeFiles(dir: string) {
-  const files = await getAllRecipeFilesInFolder(dir);
-
-  return Promise.all(files.map(readRecipeFile));
-}
-
-class FileRepo implements RecipeRepository {
-  async getAll(): Promise<Recipe[]> {
-    throw new Error('Method not implemented.');
-  }
-
-  async add(recipe: Recipe): Promise<Recipe> {
-    // Generate some id for saving the recipe
-    const generatedId = recipe.name;
-
-    // Now save the recipe
-    await saveRecipe(recipesFolder, generatedId, recipe);
-
-    // And return it
-    return recipe;
-  }
-
-  async removeByName(name: string): Promise<boolean> {
-    throw new Error('Method not implemented.');
-  }
-
-  async getByName(name: string): Promise<Recipe> {
-    const recipesFromFiles = await readAllRecipeFiles(recipesFolder);
-    const recipe = recipesFromFiles.find(r => r.name === name);
-
-    return recipe || null;
-  }
-
-  async update(recipe: Recipe, name: string): Promise<Recipe> {
-    throw new Error('Method not implemented.');
-  }
+function readAllRecipeFiles(dir: string) {
+  return fromDirectory(dir).pipe(
+    filterEndsWith('.recipe.yaml'),
+    map(filename => path.resolve(dir, filename)),
+    readFile({ encoding: 'utf-8' }),
+    parseYamlSafe<YamlRecipeFile>(),
+    map(doc => parseRecipeFile(doc)),
+    toArray(),
+  );
 }
 
 export const RecipeFileRespository: Reader<
@@ -87,7 +52,50 @@ export const RecipeFileRespository: Reader<
 > = createReader<RecipeRepository>(ask => {
   const { paths } = useContext(AppConfigToken)(ask);
 
-  recipesFolder = getPath(PathId.Recipes);
+  const recipesFolder = getPath(PathId.Recipes);
+  const allRecipes = new BehaviorSubject<Recipe[]>([]);
 
-  return new FileRepo();
+  const getAll: RecipeRepository['getAll'] = () =>
+    readAllRecipeFiles(recipesFolder).pipe(
+      tap(items => allRecipes.next(items)),
+    );
+
+  const getByName: RecipeRepository['getByName'] = name =>
+    getAll().pipe(map(f => f.find(c => c.name === name)));
+
+  return {
+    // Queries
+    getAll,
+    getByName,
+    // Commands
+    add: recipe =>
+      of(recipe).pipe(
+        mergeMap(r => {
+          // Generate some id for saving the recipe
+          const generatedId = recipe.name;
+
+          // Now save the recipe
+          return from(saveRecipe(recipesFolder, generatedId, recipe)).pipe(
+            mapTo(r),
+          );
+        }),
+        tap(c => allRecipes.next([...allRecipes.value, c])),
+      ),
+    removeByName: id =>
+      getByName(id).pipe(
+        map(x => {
+          if (x === undefined) {
+            return false;
+          }
+
+          const indexOfItem = allRecipes.value.indexOf(x);
+          allRecipes.next(allRecipes.value.filter((_, i) => i !== indexOfItem));
+          return true;
+        }),
+      ),
+    // add: recipe =>
+    update: (r, name) => {
+      throw new Error('Method not implemented.');
+    },
+  };
 });

--- a/packages/domain-rx/src/recipe-collection/create-collection.effect.ts
+++ b/packages/domain-rx/src/recipe-collection/create-collection.effect.ts
@@ -1,4 +1,3 @@
-import { from } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { act, useContext, matchEvent } from '@marblejs/core';
@@ -27,7 +26,6 @@ export const createCollection: MsgEffect = (event$, ctx) => {
         event.payload,
         createRecipeCollection,
         repo.add,
-        x => from(x),
         mergeMap(collection => [
           RecipeCollectionCreatedEvent.create(collection),
           reply(event)(RecipeCollectionCreatedEvent.create(collection)),

--- a/packages/domain-rx/src/recipe-collection/get-all.effect.ts
+++ b/packages/domain-rx/src/recipe-collection/get-all.effect.ts
@@ -1,4 +1,4 @@
-import { from, of } from 'rxjs';
+import { of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { act, useContext, matchEvent } from '@marblejs/core';
@@ -17,7 +17,6 @@ export const getAll: MsgEffect = (event$, ctx) => {
       pipe(
         undefined,
         repo.getAll,
-        x => from(x),
         map(payload =>
           reply(event)({ type: 'GET_ALL_COLLECTION_RESULT', payload }),
         ),

--- a/packages/domain-rx/src/recipe-collection/get-by-id.effect.ts
+++ b/packages/domain-rx/src/recipe-collection/get-by-id.effect.ts
@@ -1,4 +1,4 @@
-import { from, of } from 'rxjs';
+import { of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { act, useContext, matchEvent } from '@marblejs/core';
@@ -18,7 +18,6 @@ export const getById: MsgEffect = (event$, ctx) => {
       pipe(
         event.payload.id,
         repo.getById,
-        x => from(x),
         map(payload =>
           reply(event)({ type: 'GET_COLLECTION_RESULT', payload }),
         ),

--- a/packages/domain-rx/src/recipe/get-by-name.effect.ts
+++ b/packages/domain-rx/src/recipe/get-by-name.effect.ts
@@ -1,4 +1,4 @@
-import { from, of } from 'rxjs';
+import { of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { act, useContext, matchEvent } from '@marblejs/core';
@@ -26,7 +26,6 @@ export const getRecipeByName: MsgEffect = (event$, ctx) => {
       pipe(
         event.payload.name,
         repo.getByName,
-        x => from(x),
         map(payload => reply(event)({ type: `${eventType}_RESULT`, payload })),
         // catchError(error =>
         //   of({

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint --ext .ts .",
     "precommit": "lint-staged"
   },
+  "dependencies": {
+    "rxjs": "~6.6.0"
+  },
   "devDependencies": {
     "lint-staged": "^10.5.1",
     "typescript": "~4.0.2"

--- a/packages/domain/src/repositories/recipe-collection.repository.ts
+++ b/packages/domain/src/repositories/recipe-collection.repository.ts
@@ -1,3 +1,5 @@
+import { Observable } from 'rxjs';
+
 import { RecipeCollection } from '../recipe-collection';
 
 /**
@@ -7,26 +9,26 @@ export interface RecipeCollectionRepository {
   /**
    * Get all recipe collections
    */
-  getAll(): Promise<RecipeCollection[]>;
+  getAll(): Observable<RecipeCollection[]>;
 
   /**
    * Creates a new recipe collection
    */
-  add(collection: RecipeCollection): Promise<RecipeCollection>;
+  add(collection: RecipeCollection): Observable<RecipeCollection>;
 
   /**
    * Deletes a recipe collection using the `id`.
    *
    * @param id ID of the collection to remove
    */
-  removeById(id: RecipeCollection['id']): Promise<boolean>;
+  removeById(id: RecipeCollection['id']): Observable<boolean>;
 
   /**
    * Gets a recipe by its `id`
    *
    * @param id
    */
-  getById(id: RecipeCollection['id']): Promise<RecipeCollection | undefined>;
+  getById(id: RecipeCollection['id']): Observable<RecipeCollection | undefined>;
 
   /**
    * Update a recipe collection
@@ -37,5 +39,5 @@ export interface RecipeCollectionRepository {
   update(
     collection: RecipeCollection,
     id: RecipeCollection['id'],
-  ): Promise<RecipeCollection>;
+  ): Observable<RecipeCollection | undefined>;
 }

--- a/packages/domain/src/repositories/recipe.repository.ts
+++ b/packages/domain/src/repositories/recipe.repository.ts
@@ -1,3 +1,5 @@
+import { Observable } from 'rxjs';
+
 import { Recipe } from '../recipe';
 
 /**
@@ -7,24 +9,24 @@ export interface RecipeRepository {
   /**
    * Get all recipes
    */
-  getAll(): Promise<Recipe[]>;
+  getAll(): Observable<Recipe[]>;
 
   /**
    * Creates a new recipe
    */
-  add(recipe: Recipe): Promise<Recipe>;
+  add(recipe: Recipe): Observable<Recipe>;
 
   /**
    * Deletes a recipe
    * @param name
    */
-  removeByName(name: Recipe['name']): Promise<boolean>;
+  removeByName(name: Recipe['name']): Observable<boolean>;
 
   /**
    * Gets a recipe by its name
    * @param name
    */
-  getByName(name: Recipe['name']): Promise<Recipe | undefined>;
+  getByName(name: Recipe['name']): Observable<Recipe | undefined>;
 
   /**
    * Update a recipe
@@ -32,5 +34,5 @@ export interface RecipeRepository {
    * @param recipe
    * @param name
    */
-  update(recipe: Recipe, name: Recipe['name']): Promise<Recipe>;
+  update(recipe: Recipe, name: Recipe['name']): Observable<Recipe | undefined>;
 }

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -4,7 +4,13 @@
     "outDir": "./dist",
     "sourceMap": true,
     "declaration": true,
-    "target": "es2015"
+    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
+    "module": "commonjs",
+    "target": "es2019",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src"]
 }

--- a/packages/frontend/src/app/recipes/pages/recipe/recipe.component.ts
+++ b/packages/frontend/src/app/recipes/pages/recipe/recipe.component.ts
@@ -20,8 +20,6 @@ export class RecipePageComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    console.log('lol?');
-
     this.recipe$ = this.route.paramMap.pipe(
       switchMap(paramMap => this.recipeService.get(paramMap.get('id'))),
     );

--- a/packages/server-cli/src/dependencies/in-memory/in-memory-repo.ts
+++ b/packages/server-cli/src/dependencies/in-memory/in-memory-repo.ts
@@ -1,16 +1,53 @@
+import { BehaviorSubject, Observable, of, OperatorFunction } from 'rxjs';
+import { tap, map } from 'rxjs/operators';
+
 export abstract class InMemoryRepo<T> {
-  protected all: T[] = [];
+  protected all: BehaviorSubject<T[]>;
 
-  _add(item: T) {
-    this.all.push(item);
+  constructor(protected initialValue: T[] = []) {
+    this.all = new BehaviorSubject(initialValue);
   }
 
-  _remove(item: T) {
-    const lengthBefore = this.all.length;
-    this.all = this.all.filter(i => !this.equals(i, item));
-
-    return this.all.length !== lengthBefore;
+  _add(item: T): Observable<T> {
+    return of(item).pipe(tap(i => this.all.next([...this.all.value, i])));
   }
 
-  abstract equals(a: T, b: T): boolean;
+  _remove(item: Partial<T>): Observable<boolean> {
+    return this.findItem(item).pipe(
+      map(x => {
+        if (x === undefined) {
+          return false;
+        }
+
+        const indexOfItem = this.all.value.indexOf(x);
+        this.all.next(this.all.value.filter((_, i) => i !== indexOfItem));
+        return true;
+      }),
+    );
+  }
+
+  _update(item: T): Observable<T | undefined> {
+    // return of(item).pipe
+    return this.all.pipe(
+      this.findItem2(item),
+      tap(x => {
+        if (x) {
+          const indexOfItem = this.all.value.indexOf(x);
+          this.all.next(
+            this.all.value.map((x, i) => (i === indexOfItem ? item : x)),
+          );
+        }
+      }),
+    );
+  }
+
+  findItem(item: Partial<T>): Observable<T | undefined> {
+    return this.all.pipe(map(items => items.find(i => this.equals(i, item))));
+  }
+
+  findItem2(item: Partial<T>): OperatorFunction<T[], T | undefined> {
+    return map(items => items.find(i => this.equals(i, item)));
+  }
+
+  abstract equals(a: T, b: Partial<T>): boolean;
 }

--- a/packages/server-cli/src/dependencies/in-memory/recipe-collection.repository.ts
+++ b/packages/server-cli/src/dependencies/in-memory/recipe-collection.repository.ts
@@ -1,5 +1,6 @@
 import { Context, createReader } from '@marblejs/core';
 import { Reader } from 'fp-ts/lib/Reader';
+import { Observable } from 'rxjs';
 
 import { RecipeCollectionRepository } from '@overckd/domain/dist/repositories/recipe-collection.repository';
 import { RecipeCollection } from '@overckd/domain/dist/recipe-collection';
@@ -10,9 +11,7 @@ class RecipeCollectionRepo
   extends InMemoryRepo<RecipeCollection>
   implements RecipeCollectionRepository {
   constructor() {
-    super();
-
-    this.all = [
+    super([
       {
         id: 'collection1',
         name: 'collection 1',
@@ -39,54 +38,33 @@ class RecipeCollectionRepo
           },
         ],
       },
-    ];
+    ]);
   }
 
-  async removeById(id: string): Promise<boolean> {
-    const item = this.findById(id);
-    if (!item) {
-      return false;
-    }
-
-    return this._remove(item);
+  getAll(): Observable<RecipeCollection[]> {
+    return this.all.asObservable();
   }
 
-  async getById(id: string): Promise<RecipeCollection | undefined> {
-    return this.findById(id);
+  getById(id: string): Observable<RecipeCollection | undefined> {
+    return this.findItem({ id });
   }
 
-  async update(
+  add(collection: RecipeCollection): Observable<RecipeCollection> {
+    return this._add(collection);
+  }
+
+  removeById(id: string): Observable<boolean> {
+    return this._remove({ id });
+  }
+
+  update(
     collection: RecipeCollection,
     id: string,
-  ): Promise<RecipeCollection> {
-    const item = this.findById(id);
-
-    if (item) {
-      const index = this.all.indexOf(item);
-      this.all[index] = collection;
-    }
-
-    return collection;
+  ): Observable<RecipeCollection | undefined> {
+    return this._update(collection);
   }
 
-  async add(collection: RecipeCollection): Promise<RecipeCollection> {
-    this._add(collection);
-    return collection;
-  }
-
-  async getAll(): Promise<RecipeCollection[]> {
-    return this.all;
-  }
-
-  findById(id: string): RecipeCollection | undefined {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const fakeItem: RecipeCollection = { id };
-
-    return this.all.find(i => this.equals(i, fakeItem));
-  }
-
-  equals(a: RecipeCollection, b: RecipeCollection): boolean {
+  equals(a: RecipeCollection, b: Partial<RecipeCollection>): boolean {
     return a.id === b.id;
   }
 }

--- a/packages/server-cli/src/dependencies/in-memory/recipe.repository.ts
+++ b/packages/server-cli/src/dependencies/in-memory/recipe.repository.ts
@@ -1,44 +1,44 @@
 import { Context, createReader } from '@marblejs/core';
 import { Reader } from 'fp-ts/lib/Reader';
+import { Observable } from 'rxjs';
 
 import { Recipe } from '@overckd/domain/dist/recipe';
-
-import { InMemoryRepo } from './in-memory-repo';
 import { RecipeRepository } from '@overckd/domain/dist/repositories';
 
+import { InMemoryRepo } from './in-memory-repo';
+
 class RecipeRepo extends InMemoryRepo<Recipe> implements RecipeRepository {
-  async add(recipe: Recipe): Promise<Recipe> {
-    this._add(recipe);
-    return recipe;
+  constructor() {
+    super([
+      {
+        name: 'recipe 1',
+        images: [],
+        ingredients: [],
+        steps: [],
+        styles: {},
+        tips: [],
+      },
+    ]);
   }
 
-  async getAll(): Promise<Recipe[]> {
-    return this.all;
+  getAll(): Observable<Recipe[]> {
+    return this.all.asObservable();
   }
 
-  async removeByName(name: string): Promise<boolean> {
-    const recipe = this.findByName(name);
-    if (!recipe) {
-      return false;
-    }
-
-    return this._remove(recipe);
+  getByName(name: string): Observable<Recipe | undefined> {
+    return this.findItem({ name });
   }
 
-  async getByName(name: string): Promise<Recipe | undefined> {
-    return this.findByName(name);
+  add(recipe: Recipe): Observable<Recipe> {
+    return this._add(recipe);
   }
 
-  async update(recipe: Recipe, name: string): Promise<Recipe> {
+  removeByName(name: string): Observable<boolean> {
+    return this._remove({ name });
+  }
+
+  update(recipe: Recipe, name: string): Observable<Recipe | undefined> {
     throw new Error('Method not implemented.');
-  }
-
-  findByName(name: string): Recipe | undefined {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const fakeRecipe: Recipe = { name };
-
-    return this.all.find(i => this.equals(i, fakeRecipe));
   }
 
   equals(a: Recipe, b: Recipe): boolean {

--- a/packages/server/src/route/api/recipe/recipe.effects.ts
+++ b/packages/server/src/route/api/recipe/recipe.effects.ts
@@ -1,7 +1,7 @@
-import { r, HttpStatus, useContext, use, combineRoutes } from '@marblejs/core';
-import { map, mapTo, mergeMap } from 'rxjs/operators';
+import { r, HttpStatus, useContext, combineRoutes } from '@marblejs/core';
+import { map, mergeMap } from 'rxjs/operators';
 import { EventBusClientToken } from '@marblejs/messaging';
-import { requestValidator$, t } from '@marblejs/middleware-io';
+import { requestValidator$ } from '@marblejs/middleware-io';
 import { pipe } from 'fp-ts/lib/pipeable';
 
 import { GetRecipeByNameEvent, RecipeNameDto } from '@overckd/domain-rx';
@@ -54,8 +54,11 @@ const getRecipeByName$ = r.pipe(
 
         return pipe(GetRecipeByNameEvent.create(params), eventBusClient.send);
       }),
-      map(value => ({ body: value.payload })),
-      // mapTo({ status: HttpStatus.OK, b }),
+      map(value =>
+        value.payload === undefined
+          ? { status: HttpStatus.NOT_FOUND }
+          : { body: value.payload },
+      ),
     );
   }),
 );

--- a/packages/yaml-parser/src/rxjs/from-directory-as-array.ts
+++ b/packages/yaml-parser/src/rxjs/from-directory-as-array.ts
@@ -1,0 +1,12 @@
+import { from, Observable } from 'rxjs';
+
+import { readDir } from '../fs';
+
+/**
+ * An observable that emits with all files as an array, then completes.
+ *
+ * @param path
+ */
+export function fromDirectoryAsArray(path: string): Observable<string[]> {
+  return from(readDir(path));
+}

--- a/packages/yaml-parser/src/rxjs/from-directory.ts
+++ b/packages/yaml-parser/src/rxjs/from-directory.ts
@@ -1,0 +1,14 @@
+import { Observable, of } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+
+import { fromDirectoryAsArray } from './from-directory-as-array';
+
+/**
+ * An observable that emits for every file in the given
+ * directory, then completes
+ *
+ * @param path Path to the directory
+ */
+export function fromDirectory(path: string): Observable<string> {
+  return fromDirectoryAsArray(path).pipe(mergeMap(paths => of(...paths)));
+}

--- a/packages/yaml-parser/src/rxjs/index.ts
+++ b/packages/yaml-parser/src/rxjs/index.ts
@@ -1,4 +1,6 @@
 export * from './from-file';
 export * from './from-yaml-file';
+export * from './from-directory';
+export * from './from-directory-as-array';
 
 export * from './from-recipe-collection';

--- a/packages/yaml-parser/src/rxjs/operators/index.ts
+++ b/packages/yaml-parser/src/rxjs/operators/index.ts
@@ -1,1 +1,2 @@
 export * from './parse-yaml';
+export * from './read-file.operator';

--- a/packages/yaml-parser/src/rxjs/operators/parse-yaml.ts
+++ b/packages/yaml-parser/src/rxjs/operators/parse-yaml.ts
@@ -5,6 +5,8 @@ import { map } from 'rxjs/operators';
 
 import * as yaml from 'js-yaml';
 
+import { parseYamlSafe as parse } from '../../yaml';
+
 export function parseYamlSafe<T>(
   opts?: yaml.LoadOptions,
 ): OperatorFunction<string, T>;
@@ -21,5 +23,5 @@ export function parseYamlSafe(
 export function parseYamlSafe(
   opts?: yaml.LoadOptions,
 ): OperatorFunction<string, string | object | undefined> {
-  return map(fileContent => yaml.safeLoad(fileContent, opts));
+  return map(fileContent => parse(fileContent, opts));
 }

--- a/packages/yaml-parser/src/rxjs/operators/read-file.operator.ts
+++ b/packages/yaml-parser/src/rxjs/operators/read-file.operator.ts
@@ -1,0 +1,27 @@
+import { BaseEncodingOptions, PathLike } from 'fs';
+
+import { OperatorFunction } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+
+import { readFile as _readFile } from '../../fs';
+
+type Input = PathLike | number;
+
+export function readFile(
+  options?: { encoding?: null; flag?: string } | null,
+): OperatorFunction<Input, Buffer>;
+
+export function readFile(
+  options: { encoding: BufferEncoding; flag?: string } | string,
+): OperatorFunction<Input, string>;
+
+/**
+ * Operator to read the file
+ *
+ * @param options The options for reading the file
+ */
+export function readFile(
+  options?: (BaseEncodingOptions & { flag?: string }) | string | null,
+): OperatorFunction<Input, Buffer | string> {
+  return mergeMap(filepath => _readFile(filepath, options));
+}


### PR DESCRIPTION
- Change repository interfaces to use `Observable` instead of `Promise`
- Adapt repository interface implementations
- Add @ckapp/rxjs as a dependency